### PR TITLE
add endDate param

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>it.dm</groupId>
     <artifactId>metrics-trimmer</artifactId>
-    <version>1.0</version>
+    <version>2.0</version>
 
     <properties>
         <maven.compiler.source>11</maven.compiler.source>


### PR DESCRIPTION
Add an optional `--endDate` parameter that allows you to trim off metrics that occured past the given date.

There is some refactoring methods to aid readability.

